### PR TITLE
added a command that displays all the commands for the bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -28,9 +28,9 @@ async def on_ready():
     await channel.send("Salmaan sucks at fantasy")
 
 @bot.command()
-async def helpme(ctx):
+async def commands(ctx):
     ''' Displays information about available bot commands '''
-    help_message = "**Available Commands:**\n\n"
+    help_message = "**Available Commands:**\n"
 
     for command in bot.commands:
         # Exclude the default !help command

--- a/bot.py
+++ b/bot.py
@@ -28,6 +28,25 @@ async def on_ready():
     await channel.send("Salmaan sucks at fantasy")
 
 @bot.command()
+async def helpme(ctx):
+    ''' Displays information about available bot commands '''
+    help_message = "**Available Commands:**\n\n"
+
+    for command in bot.commands:
+        # Exclude the default !help command
+        if command.name != 'help':
+            help_message += f"**!{command.name}:** {command.callback.__doc__}\n"
+
+    await ctx.send(help_message)
+
+
+@bot.event
+async def on_command_error(ctx, error):
+    if isinstance(error, commands.CommandError):
+        await ctx.send(f"Error: {error}")
+
+
+@bot.command()
 async def stats(ctx):
     ''' Test function '''
     await ctx.send("Checking stats")
@@ -35,7 +54,7 @@ async def stats(ctx):
 @bot.command()
 async def daily(ctx):
     ''' Returns the top 5 fantasy players from each game 
-    played today based off ESPN's point system '''
+    played today based off ESPN's point system'''
     yesterday_str = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime("%m/%d/%Y")
     season = "2023-24"
 


### PR DESCRIPTION
# Pull Request: Introduce `!helpme` Command

## Overview
In this pull request, we introduce a new bot command: `!helpme`. This command is designed to provide users with a convenient way to view all available commands for the bot. The functionality is dynamic, accommodating any future additions to the list of bot commands. It's crucial to ensure that comprehensive documentation is provided for any new bot commands added.

## New Command: `!helpme`
The `!helpme` command displays a list of all available bot commands, offering users a quick reference to the bot's capabilities.

### Usage:
```plaintext
!helpme
```

closes #7 
